### PR TITLE
fix: query was defined incorrectly

### DIFF
--- a/test/mountebankSerialiser.js
+++ b/test/mountebankSerialiser.js
@@ -29,7 +29,7 @@ export const mbMatchesToPact = (imposters) => {
         method: match.request.method,
         path: match.request.path,
         body: match.request.body ? JSON.parse(match.request.body) : undefined,
-        query: match.request.query,
+        query: match.request.query ? new URLSearchParams(match.request.query).toString() : undefined,
         headers: match.request.headers,
       },
       response: {


### PR DESCRIPTION
The way that the `query` in the contract was being generated by the `mountebankSerialiser` was invalid, causing an error in Pactflow when trying to do a contract comparison:

![image](https://user-images.githubusercontent.com/56266602/177189109-fc429299-5ce0-4a10-b51c-dcb15c5dc1cf.png)
